### PR TITLE
build-docker: Check for node before attempting mknod

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -3,7 +3,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc && echo 1 > /proc/sys/fs/binfmt_misc/status
 for i in $(seq 1 10); do
-  mknod -m640 /dev/loop$i b 7 $i
+  if [ ! -b "/dev/loop$i" ]; then
+    mknod -m640 "/dev/loop$i" b 7 "$i"
+  fi
 done
 
 BUILD_OPTS="$*"


### PR DESCRIPTION
If the block devices already exists do not attempt to create them or
the script will exit in error.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>